### PR TITLE
🚑 Fix: 회원탈퇴 안되는 이슈

### DIFF
--- a/src/databases/rdb/entities/routine-todo.entity.ts
+++ b/src/databases/rdb/entities/routine-todo.entity.ts
@@ -36,6 +36,8 @@ export default class RoutineTodo {
   })
   user!: User;
 
-  @ManyToOne(() => Routine, (routine) => routine.routineTodos)
+  @ManyToOne(() => Routine, (routine) => routine.routineTodos, {
+    onDelete: "CASCADE",
+  })
   routine!: Routine;
 }


### PR DESCRIPTION
회원탈퇴 시 routine-todo 데이터가 있는 경우, foreign key로 인해 delete query가 동작하지 않음