### PR TITLE
🚑 Fix: 새로고침 시 다른 로그인 유저 정보 가져오는 이슈 처리

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,4 +1,4 @@
-import { GetSocialURLRequestParamDTO, ReissueTokenDTO } from "@/dto/auth.dto";
+import { GetSocialURLRequestParamDTO, ReissueTokenRequestParamDTO } from "@/dto/auth.dto";
 import { authService } from "@/loaders/service.loader";
 import { RequestDTOHandler } from "@/types/express.custom";
 
@@ -24,10 +24,10 @@ export const getSocialURLController: RequestDTOHandler<GetSocialURLRequestParamD
  * @param req Request
  * @param res Response
  */
-export const reissueTokenController: RequestDTOHandler<ReissueTokenDTO> = async (req, res) => {
-  const { nickname, type } = res.locals.requestDTO;
+export const reissueTokenController: RequestDTOHandler<ReissueTokenRequestParamDTO> = async (req, res) => {
+  const { nickname, socialKey, socialType } = res.locals.userInfo;
 
-  const result = await authService.login(nickname, type);
+  const result = await authService.login(nickname, socialType, socialKey);
 
   res.result(result);
 };

--- a/src/dto/auth.dto.ts
+++ b/src/dto/auth.dto.ts
@@ -8,19 +8,6 @@ export class ReissueTokenRequestParamDTO {
   }
 }
 
-export class ReissueTokenDTO extends ReissueTokenRequestParamDTO {
-  nickname: string;
-
-  type: TSocialType;
-
-  constructor(token: string, nickname: string, type: TSocialType) {
-    super(token);
-
-    this.nickname = nickname;
-    this.type = type;
-  }
-}
-
 export class GetSocialURLRequestParamDTO {
   type: TSocialType;
 

--- a/src/middlewares/check-expire-token.ts
+++ b/src/middlewares/check-expire-token.ts
@@ -1,4 +1,4 @@
-import { ReissueTokenDTO, ReissueTokenRequestParamDTO } from "@/dto/auth.dto";
+import { ReissueTokenRequestParamDTO } from "@/dto/auth.dto";
 import { authService } from "@/loaders/service.loader";
 import { RequestDTOHandler } from "@/types/express.custom";
 import CError, { ERROR_MESSAGE } from "@/utils/error";
@@ -28,9 +28,9 @@ export const checkExpireRefreshToken: RequestDTOHandler<ReissueTokenRequestParam
   try {
     const { refreshToken } = res.locals.requestDTO;
 
-    const payload = await authService.validateRefreshToken(refreshToken);
+    const userInfo = await authService.getUserInfoByRefreshToken(refreshToken);
 
-    res.locals.requestDTO = new ReissueTokenDTO(refreshToken, payload.nickname, payload.type);
+    res.locals.userInfo = userInfo;
 
     next();
   } catch (error) {


### PR DESCRIPTION
refresh token으로 로그인 처리를 할 때, social type과 social key로 조회된 값을 로그인 유저로 처리함 refresh token은 social key가 없기에, social type 유저 중 첫번째로 조회된 유저로 로그인처리가 됨 refresh token validate 할 때, 유저 정보를 가져와 저장한 후 처리하도록 변경